### PR TITLE
resilmesh_network added to containers

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -5,8 +5,4 @@ services:
     volumes:
       - ./config/config.yaml:/app/config/config.yaml
     networks:
-      - casm_isim_test_network
-
-networks:
-  casm_isim_test_network:
-    name: casm_isim_test_network
+      - resilmesh_network


### PR DESCRIPTION
it will be declared in the root compose file within Docker-Compose repository, which will cascade include all the other compose files: Docker-Compose->Situation-Assessment->CSA